### PR TITLE
Surround version import in try/except block

### DIFF
--- a/tidynamics/__init__.py
+++ b/tidynamics/__init__.py
@@ -1,3 +1,7 @@
 
 from ._correlation import acf, msd, cross_displacement, correlation
-from .version import __version__ as __version__
+
+try:
+    from .version import __version__ as __version__
+except ModuleNotFoundError as e:
+    __version__ = "dev"


### PR DESCRIPTION
This defaults the __version__ to 'dev' should the version.py file not be
found on import. This occurs when importing tidynamics from the
source directory. This commit is a fix for #3.